### PR TITLE
Add .fleet/ folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .classpath
 .idea
 .vscode
+.fleet
 .DS_Store
 bin
 build


### PR DESCRIPTION
Since I was testing out the new Fleet editor from JetBrains, I saw that the directory for its local files was not ignored.