### PR TITLE
Upgrade Gradle wrapper version

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
The Gradle wrapper version was kind of outdated.

So I'm using Java 17.

```
$ java --version
openjdk 17.0.2 2022-01-18
OpenJDK Runtime Environment (build 17.0.2+8-86)
OpenJDK 64-Bit Server VM (build 17.0.2+8-86, mixed mode, sharing)
```

And I tried building the project and I got an error.
```
$ ./gradlew clean build

FAILURE: Build failed with an exception.

* What went wrong:
Could not initialize class org.codehaus.groovy.runtime.InvokerHelper

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 544ms
```

The version of the Gradle wrapper is 5.6 which does not support JDK > 12.
Reference [here](https://docs.gradle.org/current/userguide/compatibility.html).
```
$ ./gradlew --version

------------------------------------------------------------
Gradle 5.6-rc-1
------------------------------------------------------------

Build time:   2019-07-29 11:26:26 UTC
Revision:     f51e6f079cea308de4ef2fb04bdc3b108db6eeaf

Kotlin:       1.3.41
Groovy:       2.5.4
Ant:          Apache Ant(TM) version 1.9.14 compiled on March 12 2019
JVM:          17.0.2 (Oracle Corporation 17.0.2+8-86)
OS:           Mac OS X 12.5.1 x86_64
```

That's why I updated the version to 7.5 which supports even the newest JDK - 18. It should be backward compatible so it should still support the chosen JDK 8 for this project.