### PR TITLE
Guard and return to improve indentation

### DIFF
--- a/src/main/java/doer/something/JSomethingDoer.java
+++ b/src/main/java/doer/something/JSomethingDoer.java
@@ -25,9 +25,12 @@ public class JSomethingDoer {
 
   // package-private for testing
   void maybeDoSecondLittleThing() {
-    if (feelingAmbitious()) {
-      doSecondLittleThing();
+    if (!feelingAmbitious()) {
+      System.out.println("We're not feeling that motivated today it seems.");
+      return;
     }
+
+    doSecondLittleThing();
   }
 
   private void doSecondLittleThing() {

--- a/src/main/kotlin/doer/something/SomethingDoer.kt
+++ b/src/main/kotlin/doer/something/SomethingDoer.kt
@@ -15,9 +15,12 @@ open class SomethingDoer(private val motivationLevel: Int) {
   }
 
   private fun maybeDoSecondLittleThing() {
-    if (feelingAmbitious()) {
-      doSecondLittleThing()
+    if (!feelingAmbitious()) {
+      println("We're not feeling that motivated today it seems.")
+      return
     }
+
+    doSecondLittleThing()
   }
 
   private fun doSecondLittleThing() {


### PR DESCRIPTION
Improve indentation in the implementation by moving business logic outside of nested if statements. 